### PR TITLE
Feature scheduler

### DIFF
--- a/myproject/finance_manager/serializers/asset.py
+++ b/myproject/finance_manager/serializers/asset.py
@@ -40,17 +40,24 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
 
 class ExpectAssetSerializer(serializers.Serializer):
     """
-    방식(거치, 적립, 복합)
-    기간(연/월?)
-    기대이율(수익률)
-
-    2way
-    목표액 입력 -> 추천 방식/기간/이율 산출
-    방식/기간/이율 입력 -> 결과 산출
-    해당 기간의 자본금 변화 시각화
+    {
+        "present_value": 5000,
+        "future_value": 5500,
+        "monthly_input": 150,
+        "interest": 0.12,
+        "year": null
+    }
+    {
+        "present_value": 5000,
+        "future_value": null,
+        "monthly_input": 150,
+        "interest": 0.12,
+        "year": 3
+    }
     """
 
-    way = serializers.ChoiceField(choices=[(1, "적립식"), (2, "거치식")])
-    period = serializers.IntegerField()
-    asset = serializers.IntegerField()
-    interest = serializers.FloatField()
+    present_value = serializers.FloatField(initial=5000)
+    future_value = serializers.FloatField()
+    monthly_input = serializers.IntegerField(initial=100)
+    interest = serializers.FloatField(initial=12)  # percent
+    year = serializers.IntegerField(initial=3)

--- a/myproject/finance_manager/serializers/asset.py
+++ b/myproject/finance_manager/serializers/asset.py
@@ -10,6 +10,7 @@ class StockSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         fields = ["id", "asset", "user", "ticker", "price", "shares"]
+        ordering = ["ticker"]
 
 
 class USStockSerializer(StockSerializer):
@@ -34,3 +35,22 @@ class AssetSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Asset
         fields = ["id", "user", "name", "usstock", "kostock"]
+        ordering = ["id"]
+
+
+class ExpectAssetSerializer(serializers.Serializer):
+    """
+    방식(거치, 적립, 복합)
+    기간(연/월?)
+    기대이율(수익률)
+
+    2way
+    목표액 입력 -> 추천 방식/기간/이율 산출
+    방식/기간/이율 입력 -> 결과 산출
+    해당 기간의 자본금 변화 시각화
+    """
+
+    way = serializers.ChoiceField(choices=[(1, "적립식"), (2, "거치식")])
+    period = serializers.IntegerField()
+    asset = serializers.IntegerField()
+    interest = serializers.FloatField()

--- a/myproject/finance_manager/serializers/user.py
+++ b/myproject/finance_manager/serializers/user.py
@@ -41,3 +41,4 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             # "usstock",
             # "kostock",
         ]
+        ordering = ["id"]

--- a/myproject/finance_manager/urls.py
+++ b/myproject/finance_manager/urls.py
@@ -15,8 +15,10 @@ router.register(r"comments", article_views.CommentViewSet)
 router.register(r"assets", asset_views.AssetViewSet)
 router.register(r"usstocks", asset_views.USStockViewSet)
 router.register(r"kostocks", asset_views.KOStockViewSet)
+# router.register(r"test", asset_views.get_expect_asset)
 
 # The API URLs are now determined automatically by the router.
 urlpatterns = [
     path("", include(router.urls)),
+    path("get_expect_asset/", asset_views.get_expect_asset),
 ]

--- a/myproject/finance_manager/views/asset_views.py
+++ b/myproject/finance_manager/views/asset_views.py
@@ -11,8 +11,48 @@ from finance_manager.serializers.asset import (
     USStockSerializer,
     KOStockSerializer,
     AssetSerializer,
+    ExpectAssetSerializer,
 )
 from . import LargeResultsSetPagination
+
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import serializers
+import json
+
+
+@api_view(["POST", "GET"])
+@csrf_exempt
+def get_expect_asset(request):
+    """
+    {
+        "way": "적립식",
+        "period": 20,
+        "asset": 2000,
+        "interest": 1.12
+    }
+    """
+    if request.method == "GET":
+        serializer = ExpectAssetSerializer()
+        return Response(serializer.data)
+    else:
+
+        data = request.data
+        a = data["asset"]
+        r = data["interest"]
+        n = data["period"]
+
+        if data["way"] == "적립식":
+            for i in range(1, n + 1):
+                data[f"{i}y_expect"] = (
+                    int(a * r) if i == 1 else int(a * (r ** i - 1) / (r - 1))
+                )
+        else:
+            for i in range(1, n + 1):
+                data[f"{i}y_expect"] = int(a * (r ** i))
+
+        return Response(data=data)
 
 
 class BaseViewSet(viewsets.ModelViewSet):

--- a/myproject/finance_manager/views/asset_views.py
+++ b/myproject/finance_manager/views/asset_views.py
@@ -4,7 +4,10 @@
 # from ..forms import AssetForm
 # from django.contrib.auth.decorators import login_required
 
-from rest_framework import permissions, viewsets
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import permissions, viewsets, serializers
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
 
 from finance_manager.models.asset import Asset, USStock, KOStock
 from finance_manager.serializers.asset import (
@@ -15,42 +18,108 @@ from finance_manager.serializers.asset import (
 )
 from . import LargeResultsSetPagination
 
-from rest_framework.response import Response
-from rest_framework.decorators import api_view
-from django.views.decorators.csrf import csrf_exempt
-from rest_framework import serializers
-import json
+
+class AssetScheduler:
+    # TODO: 값 검증
+    def __init__(
+        self, present_value, monthly_input, interest, future_value=None, year=None
+    ):
+        self.pv = present_value
+        self.fv = future_value
+        self.a = monthly_input
+        self.r = interest * 0.01 + 1
+        self.n = year
+        self.data = {}
+
+    def calculate(self):
+        """
+        빈 파라미터를 채우는 연산 적용
+        """
+        if self.fv is None:
+            self._calculate_fv()
+
+        elif self.n is None:
+            self._calculate_y()
+
+    def _calculate_fv(self):
+        """
+        투입금, 이자율, 기간 -> 미래 가치 계산
+        """
+        pv = self.pv
+        a = self.a
+        r = self.r
+        n = self.n
+        fvs = {}
+
+        for i in range(1, n + 1):
+            fvs[i] = {}
+
+            # 기대 자산
+            fvs[i]["future_value"] = (
+                round(pv * r + a)
+                if i == 1  # 첫해 투입분 이자 x
+                else round((pv * (r ** i)) + (a * (r ** i - 1) / (r - 1)))
+            )
+
+            # 누적 추가 투자액
+            fvs[i]["cum_input"] = a * i
+
+            # 누적 이자 = 기대 자산 - (현재 가치 + 누적 추가 투자액)
+            fvs[i]["cum_interest"] = fvs[i]["future_value"] - (pv + fvs[i]["cum_input"])
+
+        self.data["future_values"] = fvs
+        # 마지막 값 바로 찾을 수 있도록 추가
+        self.data["future_value"] = self.data["future_values"][n]["future_value"]
+
+    def _calculate_y(self):
+        """
+        미래가치, 투입금, 이자율 -> 기간 계산
+        """
+        # import numpy as np
+
+        pv = self.pv
+        fv = self.fv
+        a = self.a
+        r = self.r
+
+        i, temp_fv = 1, 0
+        fvs = {}
+        # direct
+        # n = np.log(r) / np.log(1 - (1 - r) * fv / a)
+
+        # TODO: 반복제거
+        while fv > temp_fv:
+            fvs[i] = {}
+
+            # 기대 자산
+            temp_fv = (
+                round(pv * r + a)
+                if i == 1  # 첫해 투입분 이자 x
+                else round((pv * (r ** i)) + (a * (r ** i - 1) / (r - 1)))
+            )
+            fvs[i]["future_value"] = temp_fv
+            fvs[i]["cum_input"] = a * i
+            fvs[i]["cum_interest"] = fvs[i]["future_value"] - (pv + fvs[i]["cum_input"])
+            i += 1
+
+        self.data["future_values"] = fvs
+        self.data["period"] = i - 1
 
 
 @api_view(["POST", "GET"])
 @csrf_exempt
 def get_expect_asset(request):
-    """
-    {
-        "way": "적립식",
-        "period": 20,
-        "asset": 2000,
-        "interest": 1.12
-    }
-    """
     if request.method == "GET":
         serializer = ExpectAssetSerializer()
         return Response(serializer.data)
     else:
 
         data = request.data
-        a = data["asset"]
-        r = data["interest"]
-        n = data["period"]
 
-        if data["way"] == "적립식":
-            for i in range(1, n + 1):
-                data[f"{i}y_expect"] = (
-                    int(a * r) if i == 1 else int(a * (r ** i - 1) / (r - 1))
-                )
-        else:
-            for i in range(1, n + 1):
-                data[f"{i}y_expect"] = int(a * (r ** i))
+        asset_scheduler = AssetScheduler(**data)
+        asset_scheduler.calculate()
+
+        data["expect"] = asset_scheduler.data
 
         return Response(data=data)
 


### PR DESCRIPTION
 #15 
`path("get_expect_asset/", asset_views.get_expect_asset)` 로 GET 요청시, 
`ExpectAssetSerializer` 에 정의된 컬럼에 따라서 아래 같은 값 응답.
```
{
    "present_value": 5000,
    "future_value": null,
    "monthly_input": 100,
    "interest": 12,
    "year": 3
}
```

기대자산 없이, POST 요청시 연별 기대자산 값(future_values)과 최종 기대자산 값(future_value) 응답

```
{
    "present_value": 5000,
    "future_value": null,
    "monthly_input": 100,
    "interest": 12,
    "year": 3,
    "expect": {
        "future_values": {
            "1": {
                "future_value": 5700,
                "cum_input": 100,
                "cum_interest": 600
            },
            "2": {
                "future_value": 6484,
                "cum_input": 200,
                "cum_interest": 1284
            },
            "3": {
                "future_value": 7362,
                "cum_input": 300,
                "cum_interest": 2062
            }
        },
        "future_value": 7362
    }
}
````

기간없이 POST 요청시 연별 기대자산 값(future_value), 요구기간(period) 응답

```
{
    "present_value": 5000,
    "future_value": 5700,
    "monthly_input": 100,
    "interest": 12,
    "expect": {
        "future_values": {
            "1": {
                "future_value": 5700,
                "cum_input": 100,
                "cum_interest": 600
            }
        },
        "period": 1
    }
}
```
